### PR TITLE
allow gcs_get_object to work if global bucket not set

### DIFF
--- a/R/objects.R
+++ b/R/objects.R
@@ -157,9 +157,7 @@ gcs_get_object <- function(object_name,
                            parseObject = TRUE,
                            parseFunction = gcs_parse_download){
 
-  testthat::expect_type(bucket, "character")
   testthat::expect_type(object_name, "character")
-  testthat::expect_length(bucket, 1)
   testthat::expect_length(object_name, 1)
 
   parse_gsurl <- gcs_parse_gsurls(object_name)
@@ -167,6 +165,9 @@ gcs_get_object <- function(object_name,
     object_name <- parse_gsurl$obj
     bucket <- parse_gsurl$bucket
   }
+
+  testthat::expect_type(bucket, "character")
+  testthat::expect_length(bucket, 1)
 
   object_name <- URLencode(object_name, reserved = TRUE)
 


### PR DESCRIPTION
The docs say that `bucket` is not needed if providing a `gs://...` URL; this waits to check the type of `bucket` until after the URL gets parsed, allowing the function to work with no `bucket` if the global bucket isn't set.