### PR TITLE
Allow default acls of uploaded objects

### DIFF
--- a/R/upload.R
+++ b/R/upload.R
@@ -97,7 +97,8 @@ gcs_upload <- function(file,
                          "bucketOwnerFullControl",
                          "bucketOwnerRead",
                          "projectPrivate",
-                         "publicRead"
+                         "publicRead",
+                         "default"
                        ),
                        upload_type = c("simple","resumable")){
 
@@ -170,14 +171,18 @@ gcs_upload <- function(file,
     ## resumable upload
     myMessage("Resumable upload", level = 2)
 
+    pars_args <- list(uploadType="resumable",
+                      name=name)
+    if(predefinedAcl != "default"){
+      pars_args[["predefinedAcl"]] <- predefinedAcl
+    }
+
     up <-
       googleAuthR::gar_api_generator("https://www.googleapis.com/upload/storage/v1",
                                      "POST",
                                      path_args = list(b = "myBucket",
                                                       o = ""),
-                                     pars_args = list(uploadType="resumable",
-                                                      name=name,
-                                                      predefinedAcl=predefinedAcl),
+                                     pars_args = pars_args,
                                      customConfig = list(
                                        add_headers("X-Upload-Content-Type" = type),
                                        add_headers("X-Upload-Content-Length" = file.size(temp))
@@ -244,14 +249,18 @@ gcs_upload <- function(file,
       content = upload_file(temp, type = type)
     )
 
+    pars_args <- list(uploadType="multipart",
+                      name=name)
+    if(predefinedAcl != "default"){
+      pars_args[["predefinedAcl"]] <- predefinedAcl
+    }
+
     up <-
       gar_api_generator("https://www.googleapis.com/upload/storage/v1",
                         "POST",
                         path_args = list(b = "myBucket",
                                          o = ""),
-                        pars_args = list(uploadType="multipart",
-                                         name=name,
-                                         predefinedAcl=predefinedAcl),
+                        pars_args = pars_args,
                         customConfig = list(
                           encode = "multipart",
                           httr::add_headers("Content-Type" =  "multipart/related")
@@ -267,14 +276,18 @@ gcs_upload <- function(file,
     bb <- httr::upload_file(temp, type = type)
     myMessage("Simple upload", level = 2)
 
+    pars_args <- list(uploadType="media",
+                      name=name)
+    if(predefinedAcl != "default"){
+      pars_args[["predefinedAcl"]] <- predefinedAcl
+    }
+
     up <-
       gar_api_generator("https://www.googleapis.com/upload/storage/v1",
                         "POST",
                         path_args = list(b = "myBucket",
                                          o = ""),
-                        pars_args = list(uploadType="media",
-                                         name=name,
-                                         predefinedAcl=predefinedAcl))
+                        pars_args = pars_args)
 
     req <- up(path_arguments = list(b = bucket),
               pars_arguments = list(name = name),

--- a/docs/reference/gcs_upload.html
+++ b/docs/reference/gcs_upload.html
@@ -108,7 +108,7 @@
     <pre class="usage"><span class='fu'>gcs_upload</span>(<span class='no'>file</span>, <span class='kw'>bucket</span> <span class='kw'>=</span> <span class='fu'><a href='gcs_get_global_bucket.html'>gcs_get_global_bucket</a></span>(), <span class='kw'>type</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>name</span> <span class='kw'>=</span> <span class='fu'>deparse</span>(<span class='fu'>substitute</span>(<span class='no'>file</span>)), <span class='kw'>object_function</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
   <span class='kw'>object_metadata</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>predefinedAcl</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"private"</span>, <span class='st'>"authenticatedRead"</span>,
-  <span class='st'>"bucketOwnerFullControl"</span>, <span class='st'>"bucketOwnerRead"</span>, <span class='st'>"projectPrivate"</span>, <span class='st'>"publicRead"</span>),
+  <span class='st'>"bucketOwnerFullControl"</span>, <span class='st'>"bucketOwnerRead"</span>, <span class='st'>"projectPrivate"</span>, <span class='st'>"publicRead"</span>, <span class='st'>"default"</span>),
   <span class='kw'>upload_type</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"simple"</span>, <span class='st'>"resumable"</span>))</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a> Arguments</h2>

--- a/man/gcs_upload.Rd
+++ b/man/gcs_upload.Rd
@@ -7,7 +7,7 @@
 gcs_upload(file, bucket = gcs_get_global_bucket(), type = NULL,
   name = deparse(substitute(file)), object_function = NULL,
   object_metadata = NULL, predefinedAcl = c("private", "authenticatedRead",
-  "bucketOwnerFullControl", "bucketOwnerRead", "projectPrivate", "publicRead"),
+  "bucketOwnerFullControl", "bucketOwnerRead", "projectPrivate", "publicRead", "default"),
   upload_type = c("simple", "resumable"))
 }
 \arguments{


### PR DESCRIPTION
By applying a predefined ACL to an object, the (default) object ACL is completely replaced with the predefined ACL. Support inheriting the default object ACLs.