### PR TITLE
Update zip to handle folder recursion

### DIFF
--- a/R/rsession.R
+++ b/R/rsession.R
@@ -200,10 +200,10 @@ gcs_load_all <- function(directory = getwd(),
 
   tmp2 <- tempdir()
   on.exit(unlink(tmp2))
-
+  
+  unzipped <- unzip(tmp, exdir = tmp2)
+  
   if(list){
-    unzipped <- unzip(tmp, exdir = tmp2)
-    
     new_files <- gsub(directory,exdir,gsub(tmp2, "", unzipped))
   
     return(new_files)

--- a/R/rsession.R
+++ b/R/rsession.R
@@ -171,13 +171,14 @@ gcs_save_all <- function(directory = getwd(),
 
   bucket <- as.bucket_name(bucket)
 
-  the_files <- file.path(directory,
-                         list.files(path = directory,
-                                    all.files = TRUE,
-                                    recursive = TRUE,
-                                    pattern = pattern))
-
-  zip::zipr(tmp, files = the_files)
+  the_files <- list.files(path = directory,
+                          all.files = TRUE,
+                          recursive = TRUE,
+                          pattern = pattern)
+  
+  withCallingHandlers(
+    zip::zip(tmp, files = the_files),
+    deprecated = function(e) NULL)
 
   gcs_upload(tmp, bucket = bucket, name = directory)
 
@@ -207,8 +208,11 @@ gcs_load_all <- function(directory = getwd(),
   
     return(new_files)
   }
-
-  file.copy(from = paste0(tmp2, directory), to = paste0(directory, "/.."), overwrite = FALSE, recursive = TRUE, copy.date = TRUE)
+  
+  filelist <- paste0(tmp2, "/", list.files(tmp2))
+  filelist <- filelist[filelist != tmp]
+  
+  file.copy(from = filelist, to = directory, overwrite = FALSE, recursive = TRUE, copy.date = TRUE)
 
   TRUE
 


### PR DESCRIPTION
For #112 

This moves back to zip::zip and suppresses the deprecation message. Would be good to get to zip::zipr but they have slightly different functionality.