### PR TITLE
Fix url encoding issue for multipart uploads

### DIFF
--- a/R/objects.R
+++ b/R/objects.R
@@ -293,7 +293,7 @@ gcs_metadata_object <- function(object_name = NULL,
     object_name <- parse_gsurl$obj
   }
 
-  object_name <- if(!is.null(object_name)) URLencode(object_name, reserved = TRUE)
+  object_name <- if(!is.null(object_name)) URLencode(object_name)
 
   out <- Object(name = object_name,
                 metadata = metadata,


### PR DESCRIPTION
This fixes an issue when using multipart uploading. Currently, the multipart upload fails when using an `object_name` as part of the `object_metadata` which contains a slash. The issue is related to the encoding of the `object_name`.

According to the official [Google Cloud Storage documentation](https://cloud.google.com/storage/docs/uploading-objects#rest-apis), special characters (e.g. a slash) in the `object_name` don't need to be encoded.