### PR TITLE
added format option

### DIFF
--- a/R/objects.R
+++ b/R/objects.R
@@ -91,7 +91,10 @@ parse_lo <- function(x){
   x$timeCreated <- timestamp_to_r(x$timeCreated)
   x$updated <- timestamp_to_r(x$updated)
   x$kind <- NULL
-  x$size <- vapply(as.numeric(x$size), function(x) format_object_size(x, "auto"), character(1))
+  format_unit = getOption("googleCloudStorageR.format_unit", default = "auto")
+  x$size <- vapply(as.numeric(x$size), function(x) {
+    format_object_size(x, unit = format_unit)
+    }, character(1))
 
   ## extra columns for composite objects (#73)
   x$componentCount  <- if(is.null(x$componentCount)) NA else x$componentCount


### PR DESCRIPTION
With proposed change, fixes #157.

``` r
head(googleCloudStorageR::gcs_list_objects()$size)
#> [1] "218.8 Mb"  "137.9 Mb"  "1.1 Kb"    "45.6 Kb"   "74 bytes"  "159 bytes"
options("googleCloudStorageR.format_unit" = "b")
head(googleCloudStorageR::gcs_list_objects()$size)
#> [1] "229391688 bytes" "144595139 bytes" "1169 bytes"      "46656 bytes"    
#> [5] "74 bytes"        "159 bytes"
```

<sup>Created on 2022-03-07 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

