### PR TITLE
Expose `predefinedAcl` in `gcs_save()`

### DIFF
--- a/R/rsession.R
+++ b/R/rsession.R
@@ -64,8 +64,20 @@ gcs_save_image <- function(file = ".RData",
 gcs_save <- function(...,
                      file,
                      bucket = gcs_get_global_bucket(),
-                     envir = parent.frame()){
+                     envir = parent.frame(),
+                     predefinedAcl = c(
+                       "private",
+                       "bucketLevel",
+                       "authenticatedRead",
+                       "bucketOwnerFullControl",
+                       "bucketOwnerRead",
+                       "projectPrivate",
+                       "publicRead",
+                       "default"
+                     )){
 
+  predefinedAcl <- match.arg(predefinedAcl)
+  
   tmp <- tempfile()
   on.exit(unlink(tmp))
 
@@ -73,7 +85,7 @@ gcs_save <- function(...,
 
   save(..., file = tmp, envir = envir)
 
-  gcs_upload(tmp, bucket = bucket, name = file)
+  gcs_upload(tmp, bucket = bucket, name = file, predefinedAcl = predefinedAcl)
 
 }
 


### PR DESCRIPTION
The `gcs_upload()` function uses the `predefinedAcl` argument to specify ACL for the file being uploaded. The `gcs_save()` function relies on the `gcs_upload()` function, but at the moment it does not allow specifying ACL for the file.  

This means that `gcs_save()` can fail for buckets set to “uniform” access control. Of course, this issue may be circumvented by setting the bucket’s access control to “fine-grained”, or by saving locally and then using `gcs_upload()`, but exposing the `predefinedAcl` argument of the underlying `gcs_upload()` would be a neater solution.