### PR TITLE
Set the Encoding in DESCRIPTION to please roxygen2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,3 +39,4 @@ VignetteBuilder: knitr
 RoxygenNote: 7.2.0
 Config/testthat/edition: 3
 Config/testthat/parallel: false
+Encoding: UTF-8


### PR DESCRIPTION
Otherwise it complains with:

```
roxygen2 requires Encoding: "UTF-8"
```