### PR TITLE
Remove trailing slash from `/b` and `/o` URLs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 * Allow listing of more than 1000 buckets (#163 - thanks @hidekoji)
 * Support GCS emulators and the `STORAGE_EMULATOR_HOST` environment variable
   (#176 - thanks @manuteleco)
+* Adjust request URLs for `list` and `insert` operations on buckets and objects,
+  removing a trailing slash to match the officially documented routes (#178 -
+  thanks @manuteleco)
 
 # googleCloudStorage 0.7.0
 

--- a/R/buckets.R
+++ b/R/buckets.R
@@ -142,7 +142,8 @@ gcs_list_buckets <- function(projectId,
                                    pars_args = list(project=projectId,
                                                     prefix=prefix,
                                                     projection=projection),
-                                   data_parse_function = parse_lb)
+                                   data_parse_function = parse_lb,
+                                   checkTrailingSlash = FALSE)
 
   out <- gar_api_page(lb, 
                       page_f = function(x) attr(x, "nextPageToken"),
@@ -277,7 +278,8 @@ gcs_create_bucket <-
 
   bb <- gar_api_generator(sprintf("%s/storage/v1/b", get_storage_host()),
                           "POST",
-                          pars_args = pars_args)
+                          pars_args = pars_args,
+                          checkTrailingSlash = FALSE)
 
   body <- list(
     name = name,

--- a/R/objects.R
+++ b/R/objects.R
@@ -45,11 +45,12 @@ gcs_list_objects <- function(bucket = gcs_get_global_bucket(),
                versions = versions)
   pars <- rmNullObs(pars)
 
-  lo <- gar_api_generator(sprintf("%s/storage/v1/", get_storage_host()),
-                          path_args = list(b = bucket,
-                                           o = ""),
+  lo <- gar_api_generator(sprintf("%s/storage/v1/b/%s/o",
+                                  get_storage_host(),
+                                  bucket),
                           pars_args = pars,
-                          data_parse_function = parse_lo)
+                          data_parse_function = parse_lo,
+                          checkTrailingSlash = FALSE)
   
   req <- gar_api_page(lo, 
                       page_f = function(x) attr(x, "nextPageToken"),

--- a/R/upload.R
+++ b/R/upload.R
@@ -382,11 +382,12 @@ do_simple_upload <- function(name,
   }
 
   up <-
-    gar_api_generator(sprintf("%s/upload/storage/v1", get_storage_host()),
+    gar_api_generator(sprintf("%s/upload/storage/v1/b/%s/o",
+                              get_storage_host(),
+                              bucket),
                       "POST",
-                      path_args = list(b = bucket,
-                                       o = ""),
-                      pars_args = pars_args)
+                      pars_args = pars_args,
+                      checkTrailingSlash = FALSE)
 
   req <- up(the_body = bb)
 
@@ -458,16 +459,17 @@ do_resumable_upload <- function(name,
   }
 
   up <-
-    googleAuthR::gar_api_generator(sprintf("%s/upload/storage/v1", get_storage_host()),
+    googleAuthR::gar_api_generator(sprintf("%s/upload/storage/v1/b/%s/o",
+                                           get_storage_host(),
+                                           bucket),
                                    "POST",
-                                   path_args = list(b = bucket,
-                                                    o = ""),
                                    pars_args = pars_args,
                                    customConfig = list(
                                      add_headers("X-Upload-Content-Type" = type),
                                      add_headers("X-Upload-Content-Length" = file.size(temp))
 
-                                   ))
+                                   ),
+                                   checkTrailingSlash = FALSE)
 
   # suppress empty JSON content warning (#120)
   req <- suppressWarnings(up(the_body = object_metadata))


### PR DESCRIPTION
Bucket [`list`][1] and [`insert`][2] operations have URL paths ending in `/b`. Likewise, object [`list`][3] and [`insert`][4] operations have URL paths ending in `/o`.

`googleCloudStorageR` was invoking these operations with a trailing slash (`/b/` and `/o/`, respectively). This worked because the Google Cloud Storage API seems to be lenient here. However, they still are undocumented URLs that simply happen to work, which can lead to unexpected issues. For example, it breaks compatibility with GCS emulators that might only implement the *official* API.

This commit adjusts the request URLs for these operations so that they match the documented ones (i.e., path ending in `/b` and `/o`, instead of `/b/` and `/o/`).

[1]: https://cloud.google.com/storage/docs/json_api/v1/buckets/list
[2]: https://cloud.google.com/storage/docs/json_api/v1/buckets/insert
[3]: https://cloud.google.com/storage/docs/json_api/v1/objects/list
[4]: https://cloud.google.com/storage/docs/json_api/v1/objects/insert

---

Closes #178 