### PR TITLE
retain metadata in response data

### DIFF
--- a/R/objects.R
+++ b/R/objects.R
@@ -104,8 +104,6 @@ parse_lo <- function(x){
   attr(x, "prefixes") <- prefixes
   attr(x, "metadata") <- x$metadata
   
-  x$metadata <- NULL
-  
   x
 }
 


### PR DESCRIPTION
responses currently strip metadata. this pr retains it.

it seems like there may have been an intent to preserve them as attributes, but i believe those end up being stripped later downstream (at several points, but most proximately in `my_reduce_rbind`).

super open to other implementations here, but this seems the most straightforward. this passes them babck when `detail` is `full`.

resolves #185 