### PR TITLE
Add generation parameter to gcs_load

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: googleCloudStorageR
 Type: Package
-Version: 0.7.0.9000
+Version: 0.7.0.9001
 Title: Interface with Google Cloud Storage API
 Description: Interact with Google Cloud Storage <https://cloud.google.com/storage/> 
   API in R. Part of the 'cloudyr' <https://cloudyr.github.io/> project.
@@ -40,7 +40,7 @@ Remotes:
 License: MIT + file LICENSE
 LazyData: true
 VignetteBuilder: knitr
-RoxygenNote: 7.2.1
+RoxygenNote: 7.3.2
 Config/testthat/edition: 3
 Config/testthat/parallel: false
 Encoding: UTF-8

--- a/R/rsession.R
+++ b/R/rsession.R
@@ -98,6 +98,7 @@ gcs_save <- function(...,
 #' @param bucket Bucket the stored objects are in
 #' @param envir Environment to load objects into
 #' @param saveToDisk Where to save the loaded file.  Default same file name
+#' @param generation The generation number for the noncurrent version, if you have object versioning enabled in your bucket e.g. \code{"1560468815691234"}
 #' @param overwrite If file exists, overwrite. Default TRUE.
 #'
 #' @details
@@ -115,12 +116,13 @@ gcs_load <- function(file = ".RData",
                      bucket = gcs_get_global_bucket(),
                      envir = .GlobalEnv,
                      saveToDisk = file,
+                     generation = NULL,
                      overwrite = TRUE){
 
   bucket <- as.bucket_name(bucket)
 
   gcs_get_object(file, bucket = bucket,
-                 saveToDisk = saveToDisk, overwrite = overwrite)
+                 saveToDisk = saveToDisk, overwrite = overwrite, generation = generation)
   load(saveToDisk, envir = envir)
 
   TRUE


### PR DESCRIPTION
This was a simple enhancement to allow a generation parameter in the gcs_load function that gets passed through to `gcs_get_object()`.

I did not update any tests but I did test it locally on my project and it worked as expected.

Might want to ignore that commit with the version change or overwrite the change.  I did that to facilitate local testing.